### PR TITLE
[JIG-28] INPUT 컴포넌트 개발

### DIFF
--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -8,3 +8,4 @@ export * from './switch';
 export * from './checkbox';
 export * from './typography';
 export * from './swapping';
+export * from './input';

--- a/packages/ui/src/components/input/index.module.scss
+++ b/packages/ui/src/components/input/index.module.scss
@@ -30,7 +30,7 @@
   caret-color: get-color('primary_normal');
 
   ::placeholder {
-    color: '#C7C7C8';
+    color: #c7c7c8;
   }
 
   &:focus {

--- a/packages/ui/src/components/input/index.module.scss
+++ b/packages/ui/src/components/input/index.module.scss
@@ -1,0 +1,47 @@
+.inputContainer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  padding: 10px 16px;
+  width: 400px;
+  height: 44px;
+
+  border: 1px solid get-color('line/normal/normal');
+  border-radius: get-radius('radius/4');
+
+  cursor: text;
+
+  &.invalid {
+    border: 1px solid get-color('colors_red');
+  }
+
+  &.focus {
+    border: 1px solid get-color('primary_normal');
+  }
+
+  &.disabled {
+    background-color: get-color('interaction_disable');
+  }
+}
+
+.input {
+  height: 42px;
+  flex-grow: 1;
+
+  border: none;
+
+  font-size: get-font-size('body-1-normal');
+
+  ::placeholder {
+    color: '#C7C7C8';
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &.disabled {
+    background-color: get-color('interaction_disable');
+  }
+}

--- a/packages/ui/src/components/input/index.module.scss
+++ b/packages/ui/src/components/input/index.module.scss
@@ -12,12 +12,12 @@
 
   cursor: text;
 
-  &.invalid {
-    border: 1px solid get-color('colors_red');
-  }
-
   &.focus {
     border: 1px solid get-color('primary_normal');
+  }
+
+  &.invalid {
+    border: 1px solid get-color('colors_red');
   }
 
   &.disabled {

--- a/packages/ui/src/components/input/index.module.scss
+++ b/packages/ui/src/components/input/index.module.scss
@@ -32,6 +32,7 @@
   border: none;
 
   font-size: get-font-size('body-1-normal');
+  caret-color: get-color('primary_normal');
 
   ::placeholder {
     color: '#C7C7C8';

--- a/packages/ui/src/components/input/index.module.scss
+++ b/packages/ui/src/components/input/index.module.scss
@@ -2,14 +2,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
-
-  padding: 10px 16px;
   width: 400px;
   height: 44px;
-
+  padding: 10px 16px;
   border: 1px solid get-color('line/normal/normal');
   border-radius: get-radius('radius/4');
-
   cursor: text;
 
   &.focus {
@@ -26,11 +23,9 @@
 }
 
 .input {
-  height: 42px;
   flex-grow: 1;
-
+  height: 42px;
   border: none;
-
   font-size: get-font-size('body-1-normal');
   caret-color: get-color('primary_normal');
 

--- a/packages/ui/src/components/input/index.ts
+++ b/packages/ui/src/components/input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './input';

--- a/packages/ui/src/components/input/index.ts
+++ b/packages/ui/src/components/input/index.ts
@@ -1,1 +1,2 @@
 export { Input } from './input';
+export type { InputProps } from './input';

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -1,0 +1,70 @@
+import clsx from 'clsx';
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type InputHTMLAttributes,
+} from 'react';
+
+import styles from './index.module.scss';
+import { Button } from '../button';
+import { Icon } from '../icon';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  value: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  showLeftIcon: boolean;
+  showRightIcon: boolean;
+  isInvalid?: boolean;
+}
+
+export const Input = ({
+  value,
+  onChange,
+  showLeftIcon,
+  showRightIcon,
+  isInvalid,
+  disabled,
+  ...args
+}: InputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isFocus, setIsFocus] = useState(false);
+
+  const handleClick = () => {
+    if (disabled) {
+      return;
+    }
+
+    setIsFocus(true);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div
+      className={clsx(
+        styles.inputContainer,
+        isInvalid && styles.invalid,
+        isFocus && styles.focus,
+        disabled && styles.disabled
+      )}
+      onClick={handleClick}
+      onBlur={() => setIsFocus(false)}
+    >
+      {showLeftIcon && <Icon name="IcSearch" width={20} height={20} />}
+      <input
+        className={clsx(styles.input, disabled && styles.disabled)}
+        value={value}
+        onChange={onChange}
+        ref={inputRef}
+        placeholder="Text Field"
+        {...args}
+        disabled={disabled}
+      />
+      {showRightIcon && (
+        <Button size="small" variant="filled">
+          입력
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -10,7 +10,7 @@ import styles from './index.module.scss';
 import { Button } from '../button';
 import { Icon } from '../icon';
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   showLeftIcon: boolean;

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -63,7 +63,7 @@ export const Input = ({
         disabled={disabled}
       />
       {showRightIcon && (
-        <Button size="small" variant="filled">
+        <Button size="small" variant="filled" disabled={disabled}>
           {text ? text : '입력'}
         </Button>
       )}

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -6,7 +6,6 @@ import {
   type InputHTMLAttributes,
 } from 'react';
 
-import { Typography, type TypographyTextLevel } from '../typography';
 import styles from './index.module.scss';
 
 import { Button, type ButtonProps } from '@/components/button';
@@ -17,6 +16,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   name: string;
   showLeftIcon?: boolean;
+  showRightIcon?: boolean;
   isInvalid?: boolean;
   buttonProps?: ButtonProps;
 }
@@ -25,6 +25,7 @@ export const Input = ({
   value,
   onChange,
   showLeftIcon,
+  showRightIcon,
   isInvalid,
   disabled,
   placeholder,
@@ -41,21 +42,6 @@ export const Input = ({
 
     setIsFocus(true);
     inputRef.current?.focus();
-  };
-
-  const getTypographyLevel = (
-    _size: ButtonProps['size']
-  ): TypographyTextLevel => {
-    switch (_size) {
-      case 'large':
-        return 'heading1';
-      case 'medium':
-        return 'body1Normal';
-      case 'small':
-        return 'label1Normal';
-      default:
-        return 'label1Normal';
-    }
   };
 
   return (
@@ -79,11 +65,9 @@ export const Input = ({
         {...args}
         disabled={disabled}
       />
-      {buttonProps && (
+      {showRightIcon && (
         <Button size="small" variant="filled" {...buttonProps}>
-          <Typography level={getTypographyLevel(buttonProps.size)}>
-            {buttonProps.children ?? '입력'}
-          </Typography>
+          {buttonProps?.children ?? '입력'}
         </Button>
       )}
     </div>

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -16,6 +16,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   showLeftIcon: boolean;
   showRightIcon: boolean;
   isInvalid?: boolean;
+  text?: string;
 }
 
 export const Input = ({
@@ -25,6 +26,7 @@ export const Input = ({
   showRightIcon,
   isInvalid,
   disabled,
+  text,
   ...args
 }: InputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -62,7 +64,7 @@ export const Input = ({
       />
       {showRightIcon && (
         <Button size="small" variant="filled">
-          입력
+          {text ? text : '입력'}
         </Button>
       )}
     </div>

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -13,6 +13,7 @@ import { Icon } from '../icon';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  name: string;
   showLeftIcon?: boolean;
   showRightIcon?: boolean;
   isInvalid?: boolean;

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -6,29 +6,29 @@ import {
   type InputHTMLAttributes,
 } from 'react';
 
+import { Typography, type TypographyTextLevel } from '../typography';
 import styles from './index.module.scss';
-import { Button } from '../button';
-import { Icon } from '../icon';
+
+import { Button, type ButtonProps } from '@/components/button';
+import { Icon } from '@/components/icon';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   name: string;
   showLeftIcon?: boolean;
-  showRightIcon?: boolean;
   isInvalid?: boolean;
-  text?: string;
+  buttonProps?: ButtonProps;
 }
 
 export const Input = ({
   value,
   onChange,
   showLeftIcon,
-  showRightIcon,
   isInvalid,
   disabled,
-  text,
   placeholder,
+  buttonProps,
   ...args
 }: InputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -41,6 +41,21 @@ export const Input = ({
 
     setIsFocus(true);
     inputRef.current?.focus();
+  };
+
+  const getTypographyLevel = (
+    _size: ButtonProps['size']
+  ): TypographyTextLevel => {
+    switch (_size) {
+      case 'large':
+        return 'heading1';
+      case 'medium':
+        return 'body1Normal';
+      case 'small':
+        return 'label1Normal';
+      default:
+        return 'label1Normal';
+    }
   };
 
   return (
@@ -64,9 +79,11 @@ export const Input = ({
         {...args}
         disabled={disabled}
       />
-      {showRightIcon && (
-        <Button size="small" variant="filled" disabled={disabled}>
-          {text ? text : '입력'}
+      {buttonProps && (
+        <Button size="small" variant="filled" {...buttonProps}>
+          <Typography level={getTypographyLevel(buttonProps.size)}>
+            {buttonProps.children ?? '입력'}
+          </Typography>
         </Button>
       )}
     </div>

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -27,6 +27,7 @@ export const Input = ({
   isInvalid,
   disabled,
   text,
+  placeholder,
   ...args
 }: InputProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -58,7 +59,7 @@ export const Input = ({
         value={value}
         onChange={onChange}
         ref={inputRef}
-        placeholder="Text Field"
+        placeholder={placeholder ? placeholder : 'Text Field'}
         {...args}
         disabled={disabled}
       />

--- a/packages/ui/src/components/input/input.tsx
+++ b/packages/ui/src/components/input/input.tsx
@@ -13,8 +13,8 @@ import { Icon } from '../icon';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  showLeftIcon: boolean;
-  showRightIcon: boolean;
+  showLeftIcon?: boolean;
+  showRightIcon?: boolean;
   isInvalid?: boolean;
   text?: string;
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,9 +3,10 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["src/*"]
     },
-    "types": ["vite/client", "vite-plugin-svgr/client"]
+    "types": ["vite/client", "vite-plugin-svgr/client"],
+    "lib": ["DOM"]
   },
   "include": [
     "src",
@@ -15,5 +16,11 @@
     "__mocks__",
     "@types"
   ],
-  "exclude": ["dist", "build", "node_modules",  "**/*.test.(ts|tsx)", "**/*.stories.(ts|tsx)"]
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "**/*.test.(ts|tsx)",
+    "**/*.stories.(ts|tsx)"
+  ]
 }


### PR DESCRIPTION
JIG-28

# How to develop
div안에 input을 넣어서 검색 아이콘 및 버튼을 추가했습니다.

input에 아이콘들은 absolute로도 배치할 수 있었지만 반응형등이 들어가면 별로인것 같아서 이와 같이 작업했습니다.

div가 아니라 form이 더 맞을것 같기도하네요


따라서 input외 영역을 클릭했을때도 포커스 해야해서 ref 사용했습니다.


개선사항 말씀하시면 반영하겠습니다.


스토리북은 추후에 작업해서 한번에 추가할게요!

# Result

<img width="414" alt="스크린샷 2024-10-13 오후 6 24 31" src="https://github.com/user-attachments/assets/b4310e59-c14d-44f0-ac12-19ef03a4b937">
